### PR TITLE
spi nand: fix infinite loop issue

### DIFF
--- a/drivers/mtd/gd5f.c
+++ b/drivers/mtd/gd5f.c
@@ -614,7 +614,9 @@ static ssize_t gd5f_pagewrite(struct spi_flash_dev_s *priv, off_t address,
 
 #ifdef CONFIG_GD5F_SYNC_WRITE
   if (status & GD5F_SR_ERR_PROGRAM) {
-    spi_mark_badblock(priv, address >> priv->block_shift);
+    if (!spare) {
+      spi_mark_badblock(priv, address >> priv->block_shift);
+    }
 #ifdef CONFIG_GD5F_DEBUG
     ferr("program error block = %08x\n", address >> priv->block_shift);
 #endif

--- a/drivers/mtd/w25.c
+++ b/drivers/mtd/w25.c
@@ -778,7 +778,9 @@ static ssize_t w25_pagewrite(FAR struct spi_flash_dev_s *priv, off_t address,
 
 #ifdef CONFIG_W25_SYNC_WRITE
     if (status & W25_ERR_PROGRAM) {
-      spi_mark_badblock(priv, address >> priv->block_shift);
+      if (!spare) {
+        spi_mark_badblock(priv, address >> priv->block_shift);
+      }
 #ifdef CONFIG_W25_DEBUG
       ferr("program error block = %08x\n", address >> priv->block_shift);
 #endif

--- a/drivers/mtd/w25_qspi.c
+++ b/drivers/mtd/w25_qspi.c
@@ -720,7 +720,9 @@ static ssize_t w25_pagewrite(FAR struct spi_flash_dev_s *priv, off_t address,
 
 #ifdef CONFIG_W25_SYNC_WRITE
     if (status & W25_ERR_PROGRAM) {
-        spi_mark_badblock(priv, address >> priv->block_shift);
+        if (!spare) {
+          spi_mark_badblock(priv, address >> priv->block_shift);
+        }
 #ifdef CONFIG_W25_DEBUG
         ferr("program error block = %08x\n", address >> priv->block_shift);
 #endif


### PR DESCRIPTION
while write a page of one block is fail, mark the block as bad will enter infinite loop, so , if write spare area is fail(mark bad block), doesn't mark it any more.